### PR TITLE
Make functions public to support creating an Xcode Extension

### DIFF
--- a/Sources/Arguments.swift
+++ b/Sources/Arguments.swift
@@ -333,7 +333,7 @@ func mergeArguments(_ args: [String: String], into config: [String: String]) thr
 }
 
 // Parse a configuration file into a dictionary of arguments
-func parseConfigFile(_ data: Data) throws -> [String: String] {
+public func parseConfigFile(_ data: Data) throws -> [String: String] {
     guard let input = String(data: data, encoding: .utf8) else {
         throw FormatError.reading("Unable to read data for configuration file")
     }
@@ -534,7 +534,7 @@ private func processOption(_ key: String,
 }
 
 // Parse rule names from arguments
-func rulesFor(_ args: [String: String], lint: Bool) throws -> Set<String> {
+public func rulesFor(_ args: [String: String], lint: Bool) throws -> Set<String> {
     var rules = allRules
     rules = try args["rules"].map {
         try Set(parseRules($0))
@@ -596,7 +596,7 @@ func fileOptionsFor(_ args: [String: String], in directory: String) throws -> Fi
 
 // Parse FormatOptions from arguments
 // Returns nil if the arguments dictionary does not contain any formatting arguments
-func formatOptionsFor(_ args: [String: String]) throws -> FormatOptions? {
+public func formatOptionsFor(_ args: [String: String]) throws -> FormatOptions? {
     var options = FormatOptions.default
     var arguments = Set(formattingArguments)
 


### PR DESCRIPTION
I created an extension that uses SwiftFormat successfully. 

However, I needed to use `@testable import SwiftFormat` to access some of the internal methods. Now when I try to Archive the project, it complains about the @testable import: `Module 'SwiftFormat' was not compiled for testing`.

By exposing these three methods, I should be able to get rid of the `@testable`, and use SwiftFormat inside Xcode Source Editor Extension.

```
@testable import SwiftFormat

private func runSwiftFormat(subject: String, swiftFormatFilename: String) throws -> String {
  let swiftFormatConfig = try FileSyncManager.readFileContents(filename: swiftFormatFilename)
  let swiftFormatConfigData = swiftFormatConfig.data(using: .utf8)!

  let args = try parseConfigFile(swiftFormatConfigData) // TODO: `parseConfigFile` is an internal method

  let formatOptions = try formatOptionsFor(args) // TODO: `formatOptionsFor` is an internal method
  let lint = args.keys.contains("lint")
  let rules = try rulesFor(args, lint: lint) // TODO: `rulesFor` is an internal method

  let output = try! SwiftFormat.format(
    subject,
    rules: FormatRules.named(Array(rules)),
    options: formatOptions!)

  return output
}
```